### PR TITLE
Return stops/stations when sources=gtfs* are requested

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,11 @@ function search(params, res) {
   let filterParam = null;
   let optionalGtfsDataset = "";
 
-  if (
+  if (params["layers"] && params["layers"].includes("bikestation")) {
+    // HSL-DT offers bikesharing, stadtnavi generalizes that to vehicle_sharing
+    // so we widden the search
+    filterParam = "&osm_tag=amenity:car_sharing&osm_tag=amenity:bike_rental";
+  } else if (
     params["sources"] &&
     params["sources"].split(",").length == 1 &&
     params["sources"].split(",")[0].startsWith("gtfs")
@@ -44,7 +48,8 @@ function search(params, res) {
     }
   } else {
     filterParam =
-      "&osm_tag=!boundary&osm_tag=!railway:station&osm_tag=:!bus_stop&osm_tag=:!tram_stop&osm_tag=:!platform&osm_tag=!stop_position";
+      "&osm_tag=!amenity:car_sharing&osm_tag=!amenity:bike_rental&osm_tag=!boundary" +
+      "&osm_tag=!railway:station&osm_tag=:!bus_stop&osm_tag=:!tram_stop&osm_tag=:!platform&osm_tag=!stop_position";
   }
 
   if (
@@ -70,6 +75,8 @@ function search(params, res) {
     url += focusParam;
   }
   url += filterParam;
+  console.log(url);
+
   fetch(url)
     .then(res => res.json())
     .then(json => {

--- a/index.js
+++ b/index.js
@@ -29,20 +29,22 @@ http
 function search(params, res) {
   let bboxParam = null;
   let focusParam = null;
+  let filterParam = null;
+  let optionalGtfsDataset = "";
 
-  //ignore GTFS stop requests. Used by digitransit
   if (
     params["sources"] &&
     params["sources"].split(",").length == 1 &&
     params["sources"].split(",")[0].startsWith("gtfs")
   ) {
-    res.writeHead(200, {
-      "Content-Type": "application/json",
-      "Access-Control-Allow-Origin": "*"
-    });
-    res.write(JSON.stringify({ error: "no gtfs", features: [] }));
-    res.end();
-    return;
+    // Return bus/tram stops for GTFS stop requests.
+    filterParam = "&osm_tag=:bus_stop&osm_tag=:tram_stop&osm_tag=railway:station";
+    if ((gtfs = /^gtfs(\w*)/.exec(params["sources"])) != null) {
+      optionalGtfsDataset = gtfs[1];
+    }
+  } else {
+    filterParam =
+      "&osm_tag=!boundary&osm_tag=!railway:station&osm_tag=:!bus_stop&osm_tag=:!tram_stop&osm_tag=:!platform&osm_tag=!stop_position";
   }
 
   if (
@@ -60,13 +62,14 @@ function search(params, res) {
     focusParam = `&lon=${params["focus.point.lon"]}&lat=${params["focus.point.lat"]}`;
   }
 
-  let url = `${PHOTON_URL}/api/?q=${encodeURIComponent(params.text)}&lang=${params.lang || "en"}&osm_tag=!boundary`;
+  let url = `${PHOTON_URL}/api/?q=${encodeURIComponent(params.text)}&lang=${params.lang || "en"}`;
   if (bboxParam) {
     url += bboxParam;
   }
   if (focusParam) {
     url += focusParam;
   }
+  url += filterParam;
   fetch(url)
     .then(res => res.json())
     .then(json => {
@@ -78,7 +81,7 @@ function search(params, res) {
         "Content-Type": "application/json",
         "Access-Control-Allow-Origin": "*"
       });
-      res.write(JSON.stringify(translateResults(json)));
+      res.write(JSON.stringify(translateResults(json, optionalGtfsDataset)));
       res.end();
     })
     .catch(err => {

--- a/test/bus-stop.json
+++ b/test/bus-stop.json
@@ -1,0 +1,31 @@
+{
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [9.1170556, 48.72986],
+        "type": "Point"
+      },
+      "type": "Feature",
+      "properties": {
+        "osm_id": 332572957,
+        "country": "Deutschland",
+        "city": "Stuttgart",
+        "countrycode": "DE",
+        "postcode": "70563",
+        "locality": "Vaihingen",
+        "type": "house",
+        "osm_type": "N",
+        "osm_key": "highway",
+        "street": "M\u00f6hringer Landstra\u00dfe",
+        "district": "Vaihingen-Mitte",
+        "extra": {
+          "ref:IFOPT": "de:08111:6012:1:4"
+        },
+        "osm_value": "bus_stop",
+        "name": "Fanny-Leicht-Stra\u00dfe",
+        "state": "Baden-W\u00fcrttemberg"
+      }
+    }
+  ],
+  "type": "FeatureCollection"
+}

--- a/test/test.js
+++ b/test/test.js
@@ -120,3 +120,11 @@ it("set a label and name for an exact address with house number", function() {
     names
   );
 });
+
+it("returns bus_stop in layer stop with ifopt as gtfs id", function() {
+  const input = require("./bus-stop.json");
+  const result = translateResults(input, "mydataset");
+  assert.equal(result.features[0].properties.name, "Fanny-Leicht-Straße");
+  assert.equal(result.features[0].properties.id, "GTFS:mydataset:de:08111:6012");
+  assert.equal(result.features[0].properties.layer, "stop");
+});


### PR DESCRIPTION
This PR introduces stop/station handling.

The adapter will return bus_stops, tram_stops and stations only, when `sources=gtfsXXX` are requested (where XXX is the ID of a gtfs dataset). Their layer will be `stop` for bus_stops and tram_stops, and `station` for railway=station results.

An extra `ref:IFOPT` property (which might be optionally imported in photon) is shortened to the parent station's IFOPT and returned as `id`property with the value `GTFS:XXX:<parent station IFOPT>`. 

Example:

```
{
    "features":
    [
        {
            "geometry":
            {
                "coordinates":
                [
                    9.1170556,
                    48.72986
                ],
                "type": "Point"
            },
            "type": "Feature",
            "properties":
            {
                "osm_id": 332572957,
                "country": "Germany",
                "city": "Stuttgart",
                "countrycode": "DE",
                "locality": "Stuttgart",
                "type": "house",
                "osm_type": "N",
                "osm_key": "highway",
                "street": "M\u00f6hringer Landstra\u00dfe",
                "district": "Vaihingen-Mitte",
                "extra":
                {
                    "ref:IFOPT": "de:08111:6012:1:4"
                },
                "osm_value": "bus_stop",
                "name": "Fanny-Leicht-Stra\u00dfe",
                "region": "Baden-W\u00fcrttemberg",
                "postalcode": "70563",
                "label": "Fanny-Leicht-Stra\u00dfe, M\u00f6hringer Landstra\u00dfe, 70563 Stuttgart",
                "layer": "stop",
                "id": "GTFS:XXX:de:08111:6012"
            }
        }
    ]
}
```

